### PR TITLE
rockspec: use git+https:// for git repository URL

### DIFF
--- a/authman-scm-1.rockspec
+++ b/authman-scm-1.rockspec
@@ -1,7 +1,7 @@
 package = 'authman'
 version = 'scm-1'
 source  = {
-    url    = 'git://github.com/mailru/tarantool-authman.git',
+    url    = 'git+https://github.com/mailru/tarantool-authman.git',
     branch = 'master',
 }
 description = {


### PR DESCRIPTION
GitHub is going to disable unencrypted Git protocol, so `git://` URLs
will stop working soon (see [1]).

[1]: https://github.blog/2021-09-01-improving-git-protocol-security-github/